### PR TITLE
fix: anchor comment replies and cascade delete through thread descendants

### DIFF
--- a/src/core/ast/document/comments.tsx
+++ b/src/core/ast/document/comments.tsx
@@ -126,15 +126,16 @@ export class CommentsView {
 		);
 	}
 
-	/** Read a comment's `w14:paraId`, or undefined if the comment is missing
-	 * or has no inner `<w:p>`. Accepts the `cN` or bare-`N` id form. */
+	/** Read a comment's threading `w14:paraId`, or undefined if the comment is
+	 * missing or has no inner `<w:p>`. Word keys `<w15:commentEx>` and a
+	 * reply's `w14:paraIdParent`/`w15:paraIdParent` off the comment's LAST
+	 * paragraph, so threading must too. Accepts the `cN` or bare-`N` id form. */
 	paraIdFor(commentId: string): string | undefined {
 		const numericId = commentId.startsWith("c")
 			? commentId.slice(1)
 			: commentId;
 		const comment = this.findById(numericId);
-		const paragraph = comment?.findChild("w:p");
-		return paragraph?.getAttribute("w14:paraId");
+		return lastParagraph(comment)?.getAttribute("w14:paraId");
 	}
 
 	/** Read a comment's `w14:paraId`, minting + persisting one (and the
@@ -147,7 +148,7 @@ export class CommentsView {
 			: commentId;
 		const root = XmlNode.findRoot(this.tree, "w:comments");
 		const comment = this.findById(numericId);
-		const paragraph = comment?.findChild("w:p");
+		const paragraph = lastParagraph(comment);
 		if (!root || !paragraph) return undefined;
 		const existing = paragraph.getAttribute("w14:paraId");
 		if (existing) return existing;
@@ -176,6 +177,53 @@ export class CommentsView {
 		return String(highest + 1);
 	}
 
+	/** Numeric ids of every transitive reply chained under `commentId` via
+	 * `w15:paraIdParent`. Delete cascades through these so a removed parent
+	 * never strands its replies' body markers or dangles their thread link.
+	 * Accepts the `cN` or bare-`N` id form. */
+	descendantReplyIds(commentId: string): string[] {
+		const root = XmlNode.findRoot(this.tree, "w:comments");
+		if (!root) return [];
+		const numericId = commentId.startsWith("c")
+			? commentId.slice(1)
+			: commentId;
+
+		const extended = this.#readExtended();
+		const idByParaId = new Map<string, string>();
+		const childParaIdsByParent = new Map<string, string[]>();
+		for (const child of root.children) {
+			if (child.tag !== "w:comment") continue;
+			const childId = child.getAttribute("w:id");
+			if (childId == null) continue;
+			const paraId = lastParagraph(child)?.getAttribute("w14:paraId");
+			if (!paraId) continue;
+			idByParaId.set(paraId, childId);
+			const parentParaId = extended.get(paraId)?.parentParaId;
+			if (!parentParaId) continue;
+			const siblings = childParaIdsByParent.get(parentParaId) ?? [];
+			siblings.push(paraId);
+			childParaIdsByParent.set(parentParaId, siblings);
+		}
+
+		const startParaId = lastParagraph(this.findById(numericId))?.getAttribute(
+			"w14:paraId",
+		);
+		if (!startParaId) return [];
+
+		const out: string[] = [];
+		const queue = [startParaId];
+		while (queue.length > 0) {
+			const paraId = queue.shift();
+			if (paraId == null) continue;
+			for (const childParaId of childParaIdsByParent.get(paraId) ?? []) {
+				const childId = idByParaId.get(childParaId);
+				if (childId) out.push(childId);
+				queue.push(childParaId);
+			}
+		}
+		return out;
+	}
+
 	/** Parse this part (plus the extended sidecar) into the AST `Comment[]` the
 	 * reader exposes on `Body.comments`, and populate `commentReferences` for
 	 * mutators. `anchors` are the span ranges the body walk computed from
@@ -190,8 +238,9 @@ export class CommentsView {
 			if (child.tag !== "w:comment") continue;
 			const numericId = child.getAttribute("w:id");
 			if (numericId == null) continue;
-			const paragraph = child.findChild("w:p");
-			const paraId = paragraph?.getAttribute("w14:paraId");
+			// Threading keys off the LAST paragraph (see `paraIdFor`), so index
+			// by it to resolve a reply's `w15:paraIdParent` back to its parent.
+			const paraId = lastParagraph(child)?.getAttribute("w14:paraId");
 			if (paraId) commentIdByParaId.set(paraId, `c${numericId}`);
 		}
 
@@ -214,8 +263,7 @@ export class CommentsView {
 				endOffset: 0,
 			};
 
-			const paragraph = child.findChild("w:p");
-			const paraId = paragraph?.getAttribute("w14:paraId");
+			const paraId = lastParagraph(child)?.getAttribute("w14:paraId");
 			const meta = paraId ? (extendedByParaId.get(paraId) ?? {}) : {};
 			const parentCommentId = meta.parentParaId
 				? commentIdByParaId.get(meta.parentParaId)
@@ -278,6 +326,14 @@ export class CommentsView {
 
 function CommentsRoot(): XmlNode {
 	return <w.comments {...{ "xmlns:w": NS_W, "xmlns:w14": NS_W14 }} />;
+}
+
+/** A comment's threading identity is its LAST `<w:p>` — that's the paragraph
+ * Word keys `<w15:commentEx>` and reply `paraIdParent` links to. */
+function lastParagraph(comment: XmlNode | undefined): XmlNode | undefined {
+	if (!comment) return undefined;
+	const paragraphs = comment.findChildren("w:p");
+	return paragraphs.at(-1);
 }
 
 /** Mint a fresh `w14:paraId` value. Word writes 8-char uppercase hex; we

--- a/src/core/ast/document/comments.tsx
+++ b/src/core/ast/document/comments.tsx
@@ -126,6 +126,36 @@ export class CommentsView {
 		);
 	}
 
+	/** Insert `node` (a `<w:comment>`) immediately after the last comment in the
+	 * thread rooted at `parentNumericId` (the parent itself plus every
+	 * transitive reply), so a new reply appends after the existing thread tail
+	 * rather than jumping ahead of siblings. */
+	insertReplyAfter(parentNumericId: string, node: XmlNode): void {
+		const root = XmlNode.findRoot(this.tree, "w:comments");
+		if (!root) throw new Error("expected <w:comments> root");
+
+		const threadIds = new Set([
+			parentNumericId,
+			...this.descendantReplyIds(parentNumericId),
+		]);
+
+		let lastIndex = -1;
+		for (let i = 0; i < root.children.length; i++) {
+			const child = root.children[i];
+			if (child.tag !== "w:comment") continue;
+			const cid = child.getAttribute("w:id");
+			if (cid != null && threadIds.has(cid)) {
+				lastIndex = i;
+			}
+		}
+
+		if (lastIndex === -1) {
+			root.children.push(node);
+		} else {
+			root.children.splice(lastIndex + 1, 0, node);
+		}
+	}
+
 	/** Read a comment's threading `w14:paraId`, or undefined if the comment is
 	 * missing or has no inner `<w:p>`. Word keys `<w15:commentEx>` and a
 	 * reply's `w14:paraIdParent`/`w15:paraIdParent` off the comment's LAST

--- a/src/core/comments/index.tsx
+++ b/src/core/comments/index.tsx
@@ -7,6 +7,7 @@ import {
 	addCommentMarkersAroundRun,
 	addCommentMarkersToParagraph,
 	addCommentRangeMarkers,
+	addReplyCommentMarkers,
 	authorInitials,
 	CommentBody,
 	type CommentSpan,
@@ -20,6 +21,7 @@ export {
 	addCommentMarkersAroundRun,
 	addCommentMarkersToParagraph,
 	addCommentRangeMarkers,
+	addReplyCommentMarkers,
 	authorInitials,
 	CommentBody,
 	type CommentBodyOptions,
@@ -153,13 +155,49 @@ export class Comments {
 		const numericId = view.nextId();
 		const replyParaId = generateParaId();
 
-		this.#appendCommentBody(numericId, replyParaId, body, options.author, date);
+		// Word drops any comment without a `<w:commentReference>` in the body;
+		// mirror the parent thread's anchor markers so the reply renders. Anchor
+		// before writing any part so an unanchorable parent aborts cleanly.
+		const anchored = addReplyCommentMarkers(
+			this.document.documentTree,
+			parentNumericId,
+			numericId,
+		);
+		if (!anchored) {
+			throw new CommentsError(
+				"COMMENT_NOT_FOUND",
+				`Parent comment c${parentNumericId} has no anchor in the document body; cannot anchor reply.`,
+			);
+		}
+
+		this.#appendCommentBody(
+			numericId,
+			replyParaId,
+			body,
+			options.author,
+			date,
+			parentParaId,
+		);
 
 		const extView = this.document.ensureCommentsExtended();
 		const extRoot = extView.extendedTree
 			? XmlNode.findRoot(extView.extendedTree, "w15:commentsEx")
 			: undefined;
 		if (!extRoot) throw new Error("expected <w15:commentsEx> root");
+
+		let parentEntry = extRoot.children.find(
+			(child) =>
+				child.tag === "w15:commentEx" &&
+				child.getAttribute("w15:paraId") === parentParaId,
+		);
+		if (!parentEntry) {
+			parentEntry = new XmlNode("w15:commentEx", {
+				"w15:paraId": parentParaId,
+				"w15:done": "0",
+			});
+			extRoot.children.push(parentEntry);
+		}
+
 		extRoot.children.push(
 			new XmlNode("w15:commentEx", {
 				"w15:paraId": replyParaId,
@@ -224,7 +262,9 @@ export class Comments {
 	/** Remove every id in `ids`: splice the `<w:comment>` body, prune any
 	 * `<w15:commentEx>` entry keyed to its paraId, and strip
 	 * `<w:commentRangeStart>` / `<w:commentRangeEnd>` /
-	 * `<w:commentReference>` markers from the body. Pre-validates the
+	 * `<w:commentReference>` markers from the body. Deleting a thread parent
+	 * cascades through its replies so none are left with dangling markers or a
+	 * `w15:paraIdParent` pointing at a removed comment. Pre-validates the
 	 * batch — any unknown id aborts before any mutation. Throws
 	 * `CommentsError("COMMENT_NOT_FOUND")` with the first offending id. */
 	delete(ids: string[]): void {
@@ -241,10 +281,17 @@ export class Comments {
 		}
 		if (!view) return; // `normalized` is empty (no ids → no `view` access yet).
 
+		const expanded = new Set(normalized);
+		for (const commentId of normalized) {
+			for (const replyId of view.descendantReplyIds(commentId)) {
+				expanded.add(`c${replyId}`);
+			}
+		}
+
 		const root = XmlNode.findRoot(view.tree, "w:comments");
 		if (!root) return;
 
-		for (const commentId of normalized) {
+		for (const commentId of expanded) {
 			const numericId = commentId.slice(1);
 			const node = view.findById(numericId);
 			if (!node) continue; // pre-validated above
@@ -303,6 +350,7 @@ export class Comments {
 		text: string,
 		author: string,
 		date: string,
+		paraIdParent?: string,
 	): void {
 		const commentsView = this.document.ensureComments();
 		const commentsRoot = XmlNode.findRoot(commentsView.tree, "w:comments");
@@ -315,6 +363,7 @@ export class Comments {
 					date,
 					initials: authorInitials(author),
 					paraId,
+					...(paraIdParent ? { paraIdParent } : {}),
 					text,
 				}}
 			/>,

--- a/src/core/comments/index.tsx
+++ b/src/core/comments/index.tsx
@@ -177,6 +177,7 @@ export class Comments {
 			options.author,
 			date,
 			parentParaId,
+			parentNumericId,
 		);
 
 		const extView = this.document.ensureCommentsExtended();
@@ -198,13 +199,29 @@ export class Comments {
 			extRoot.children.push(parentEntry);
 		}
 
-		extRoot.children.push(
-			new XmlNode("w15:commentEx", {
-				"w15:paraId": replyParaId,
-				"w15:paraIdParent": parentParaId,
-				"w15:done": "0",
-			}),
-		);
+		const replyEntry = new XmlNode("w15:commentEx", {
+			"w15:paraId": replyParaId,
+			"w15:paraIdParent": parentParaId,
+			"w15:done": "0",
+		});
+		const parentEntryIndex = extRoot.children.indexOf(parentEntry);
+		if (parentEntryIndex !== -1) {
+			// Scan forward from the parent to find the last existing reply
+			// in this thread so the new reply appends after the tail.
+			let insertAfterIndex = parentEntryIndex;
+			for (let i = parentEntryIndex + 1; i < extRoot.children.length; i++) {
+				const child = extRoot.children[i];
+				if (
+					child.tag === "w15:commentEx" &&
+					child.getAttribute("w15:paraIdParent") === parentParaId
+				) {
+					insertAfterIndex = i;
+				}
+			}
+			extRoot.children.splice(insertAfterIndex + 1, 0, replyEntry);
+		} else {
+			extRoot.children.push(replyEntry);
+		}
 
 		return numericId;
 	}
@@ -351,11 +368,12 @@ export class Comments {
 		author: string,
 		date: string,
 		paraIdParent?: string,
+		afterCommentId?: string,
 	): void {
 		const commentsView = this.document.ensureComments();
 		const commentsRoot = XmlNode.findRoot(commentsView.tree, "w:comments");
 		if (!commentsRoot) throw new Error("expected <w:comments> root");
-		commentsRoot.children.push(
+		const body = (
 			<CommentBody
 				options={{
 					id: numericId,
@@ -366,8 +384,13 @@ export class Comments {
 					...(paraIdParent ? { paraIdParent } : {}),
 					text,
 				}}
-			/>,
+			/>
 		);
+		if (afterCommentId) {
+			commentsView.insertReplyAfter(afterCommentId, body);
+		} else {
+			commentsRoot.children.push(body);
+		}
 	}
 
 	#resolveBlock(blockId: string): { node: XmlNode; parent: XmlNode[] } {

--- a/src/core/comments/markers.tsx
+++ b/src/core/comments/markers.tsx
@@ -407,6 +407,7 @@ export type CommentBodyOptions = {
 	date: string;
 	initials: string;
 	paraId: string;
+	paraIdParent?: string;
 	text: string;
 };
 
@@ -422,13 +423,88 @@ export function CommentBody({
 			w-date={options.date}
 			w-initials={options.initials}
 		>
-			<w.p {...{ "w14:paraId": options.paraId, "w14:textId": "00000000" }}>
+			<w.p
+				{...{
+					"w14:paraId": options.paraId,
+					"w14:textId": "00000000",
+					...(options.paraIdParent
+						? { "w14:paraIdParent": options.paraIdParent }
+						: {}),
+				}}
+			>
 				<w.r>
 					<w.t {...{ "xml:space": "preserve" }}>{options.text}</w.t>
 				</w.r>
 			</w.p>
 		</w.comment>
 	);
+}
+
+/**
+ * Anchor a reply in the document body by mirroring the parent thread's
+ * markers for the reply's id. Word drops any comment whose
+ * `<w:commentReference>` is absent from the body, so a reply needs its own
+ * `<w:commentRangeStart>` / `<w:commentRangeEnd>` / `<w:commentReference>`
+ * nested alongside the parent's — the thread shares the parent's span.
+ * Returns true once the parent's reference run is found and the reply
+ * anchored.
+ */
+export function addReplyCommentMarkers(
+	documentTree: XmlNode[],
+	parentNumericId: string,
+	replyNumericId: string,
+): boolean {
+	const document = XmlNode.findRoot(documentTree, "w:document");
+	if (!document) return false;
+	// Bail before mutating if the parent has no reference run to mirror —
+	// otherwise we'd strand half-placed range markers in the body.
+	if (!documentHasCommentReference(document, parentNumericId)) return false;
+	let anchored = false;
+	function walk(node: XmlNode): void {
+		const result: XmlNode[] = [];
+		for (const child of node.children) {
+			result.push(child);
+			if (
+				child.tag === "w:commentRangeStart" &&
+				child.getAttribute("w:id") === parentNumericId
+			) {
+				result.push(commentRangeStartMarker(replyNumericId));
+				continue;
+			}
+			if (
+				child.tag === "w:commentRangeEnd" &&
+				child.getAttribute("w:id") === parentNumericId
+			) {
+				result.push(commentRangeEndMarker(replyNumericId));
+				continue;
+			}
+			if (
+				child.tag === "w:r" &&
+				containsCommentReference(child, parentNumericId)
+			) {
+				result.push(commentReferenceRun(replyNumericId));
+				anchored = true;
+				continue;
+			}
+			walk(child);
+		}
+		node.children = result;
+	}
+	walk(document);
+	return anchored;
+}
+
+function documentHasCommentReference(
+	node: XmlNode,
+	numericId: string,
+): boolean {
+	for (const child of node.children) {
+		if (child.tag === "w:r" && containsCommentReference(child, numericId)) {
+			return true;
+		}
+		if (documentHasCommentReference(child, numericId)) return true;
+	}
+	return false;
 }
 
 export function removeCommentMarkers(

--- a/tests/cli/comments.test.ts
+++ b/tests/cli/comments.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { Pkg } from "../../src/core/ast/document/package";
 import { runCli, tempWorkspace } from "./harness";
+
+async function readPart(docPath: string, part: string): Promise<string> {
+	const pkg = await Pkg.open(docPath);
+	return pkg.readText(part);
+}
 
 describe("docx comments", () => {
 	let docPath: string;
@@ -104,6 +110,66 @@ describe("docx comments", () => {
 		const comments = list.parsed as Array<{ id: string; parentId?: string }>;
 		expect(comments).toHaveLength(2);
 		expect(comments[1]).toMatchObject({ id: "c1", parentId: "c0" });
+
+		// Word drops any comment whose <w:commentReference> is missing from the
+		// body, so the reply must anchor its own marker alongside the parent's.
+		const documentXml = await readPart(docPath, "word/document.xml");
+		expect(documentXml).toContain('<w:commentReference w:id="1"/>');
+		expect(documentXml).toContain('<w:commentRangeStart w:id="1"/>');
+		expect(documentXml).toContain('<w:commentRangeEnd w:id="1"/>');
+		// Reply markers nest inside the parent's span, not before it.
+		expect(documentXml.indexOf('<w:commentRangeStart w:id="0"/>')).toBeLessThan(
+			documentXml.indexOf('<w:commentRangeStart w:id="1"/>'),
+		);
+		expect(documentXml.indexOf('<w:commentRangeEnd w:id="0"/>')).toBeLessThan(
+			documentXml.indexOf('<w:commentRangeEnd w:id="1"/>'),
+		);
+		// The thread link lives in both the body and the extended sidecar.
+		const commentsXml = await readPart(docPath, "word/comments.xml");
+		expect(commentsXml).toContain("w14:paraIdParent=");
+		const extendedXml = await readPart(docPath, "word/commentsExtended.xml");
+		expect(extendedXml).toContain("w15:paraIdParent=");
+	});
+
+	test("deleting a thread parent cascades to its reply", async () => {
+		await runCli(
+			"comments",
+			"add",
+			docPath,
+			"--range",
+			"p0",
+			"--text",
+			"Q?",
+			"--author",
+			"A",
+		);
+		await runCli(
+			"comments",
+			"reply",
+			docPath,
+			"--to",
+			"c0",
+			"--text",
+			"Answer",
+			"--author",
+			"B",
+		);
+
+		await runCli("comments", "delete", docPath, "--id", "c0");
+
+		const list = await runCli(
+			"comments",
+			"list",
+			docPath,
+			"--include-resolved",
+		);
+		expect((list.parsed as unknown[]).length).toBe(0);
+
+		// No orphaned reply markers or dangling thread link survive the cascade.
+		const documentXml = await readPart(docPath, "word/document.xml");
+		expect(documentXml).not.toContain("w:commentReference");
+		const extendedXml = await readPart(docPath, "word/commentsExtended.xml");
+		expect(extendedXml).not.toContain("w15:paraIdParent=");
 	});
 
 	test("resolve flips done flag and filter excludes by default", async () => {

--- a/tests/core/ast/comments-threading.test.ts
+++ b/tests/core/ast/comments-threading.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { CommentsView } from "../../../src/core/ast/document/comments";
+
+const NS = `xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"`;
+
+function multiParagraphComments(): string {
+	return `<?xml version="1.0"?><w:comments ${NS}><w:comment w:id="18" w:author="A" w:date="2020-01-01T00:00:00Z"><w:p w14:paraId="0000027A"><w:r><w:t>first</w:t></w:r></w:p><w:p w14:paraId="00000283"><w:r><w:t>last</w:t></w:r></w:p></w:comment></w:comments>`;
+}
+
+describe("comment threading identity keys off the last paragraph", () => {
+	test("paraIdFor returns the last paragraph's paraId", () => {
+		const view = CommentsView.fromXml(multiParagraphComments());
+		expect(view?.paraIdFor("18")).toBe("00000283");
+	});
+
+	test("ensureParaId reuses the last paragraph's existing paraId", () => {
+		const view = CommentsView.fromXml(multiParagraphComments());
+		expect(view?.ensureParaId("c18")).toBe("00000283");
+	});
+
+	test("a reply linked to the last paragraph resolves its parentId", () => {
+		const comments = `<?xml version="1.0"?><w:comments ${NS}><w:comment w:id="18" w:author="A" w:date="2020-01-01T00:00:00Z"><w:p w14:paraId="0000027A"><w:r><w:t>first</w:t></w:r></w:p><w:p w14:paraId="00000283"><w:r><w:t>last</w:t></w:r></w:p></w:comment><w:comment w:id="19" w:author="B" w:date="2020-01-02T00:00:00Z"><w:p w14:paraId="80CBDBBD" w14:paraIdParent="00000283"><w:r><w:t>OK</w:t></w:r></w:p></w:comment></w:comments>`;
+		const extended = `<?xml version="1.0"?><w15:commentsEx ${NS}><w15:commentEx w15:paraId="00000283" w15:done="0"/><w15:commentEx w15:paraId="80CBDBBD" w15:paraIdParent="00000283" w15:done="0"/></w15:commentsEx>`;
+		const view = CommentsView.fromXml(comments, extended);
+		const list = view?.toComments(new Map());
+		const reply = list?.find((comment) => comment.id === "c19");
+		expect(reply?.parentId).toBe("c18");
+	});
+});


### PR DESCRIPTION
## Summary

- A reply needs its own <w:commentReference> in the body or Word drops it.
- Parent deletion now walks `w15:paraIdParent` chains so no orphaned markers or dangling thread links survive.
- Fixes #1

## Test plan

- [x] Unit tests pass (669/669)
- [x] CLI integration tests verify reply anchoring and cascade delete
- [x] AST threading tests verify `paraId` identity keys off the last paragraph